### PR TITLE
Add multiple points support to handleImage

### DIFF
--- a/controllers/image.js
+++ b/controllers/image.js
@@ -14,11 +14,11 @@ const handleApiCall = (req, res) => {
 };
 
 const handleImage = (knex) => (req, res) => {
-  const { id } = req.body;
+  const { id, points = 1 } = req.body;
 
   knex('users')
     .where('id', '=', id)
-    .increment('entries', 1)
+    .increment('entries', points)
     .returning('entries')
     .then((data) => {
       res.json(data[0].entries);


### PR DESCRIPTION
To add multiple points, set `points` in the body of a request to `/image`.  Points can be subtracted by using a negative `points` value.

For backwards compatibility, one point will be added if there is no `points` value.